### PR TITLE
Updated to use new secret name

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install the Apple certificate and provisioning profile
         env:
           BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
-          P12_PASSWORD: ${{ secrets.KEYCHIAN_PASSWD }}
+          P12_PASSWORD: ${{ secrets.IOS_BUILD_CERTIFICATE_PASSWD }}
           BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.BUILD_PROD_PROVISION_PROFILE_BASE64 }}
           KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
         run: |


### PR DESCRIPTION

I'm cleaning up secret names in the bcgov organization to make them more descriptive. 'IOS_BUILD_CERTIFICATE_PASSWD' replaces 'KEYCHIAN_PASSWD'.

This pull request updates the ios-build.yml action to use the new secret.

'KEYCHIAN_PASSWD' will be removed from the org's secrets once all repos have been updated.


 